### PR TITLE
Refactor param style

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -288,16 +288,16 @@ export class Cache {
                 }
 
                 const line = fileLines[listItem.position.start.line];
-                const task = Task.fromLine({
+                const task = Task.fromLine(
                     line,
-                    path: file.path,
-                    sectionStart: currentSection.position.start.line,
+                    file.path,
+                    currentSection.position.start.line,
                     sectionIndex,
-                    precedingHeader: Cache.getPrecedingHeader(
+                    Cache.getPrecedingHeader(
                         listItem.position.start.line,
                         fileCache.headings,
                     ),
-                });
+                );
 
                 if (task !== null) {
                     sectionIndex++;

--- a/src/Commands/CreateOrEdit.ts
+++ b/src/Commands/CreateOrEdit.ts
@@ -25,7 +25,7 @@ export const createOrEdit = (
     const cursorPosition = editor.getCursor();
     const lineNumber = cursorPosition.line;
     const line = editor.getLine(lineNumber);
-    const task = taskFromLine({ line, path });
+    const task = taskFromLine(line, path);
 
     const onSubmit = (updatedTasks: Task[]): void => {
         const serialized = updatedTasks
@@ -43,14 +43,14 @@ export const createOrEdit = (
     taskModal.open();
 };
 
-const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
-    const task = Task.fromLine({
+const taskFromLine = (line: string, path: string): Task => {
+    const task = Task.fromLine(
         line,
         path,
-        sectionStart: 0, // We don't need this to toggle it here in the editor.
-        sectionIndex: 0, // We don't need this to toggle it here in the editor.
-        precedingHeader: null, // We don't need this to toggle it here in the editor.
-    });
+        0, // We don't need this to create the modal.
+        0, // We don't need this to create the modal.
+        null, // We don't need this to create the modal.
+    );
 
     if (task !== null) {
         return task;

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -48,13 +48,13 @@ export const toggleDone = (checking: boolean, editor: Editor, view: View) => {
 const toggleLine = ({ line, path }: { line: string; path: string }): string => {
     let toggledLine: string = line;
 
-    const task = Task.fromLine({
+    const task = Task.fromLine(
         line,
         path,
-        sectionStart: 0, // We don't need this to toggle it here in the editor.
-        sectionIndex: 0, // We don't need this to toggle it here in the editor.
-        precedingHeader: null, // We don't need this to toggle it here in the editor.
-    });
+        0, // We don't need this to toggle it here in the editor.
+        0, // We don't need this to toggle it here in the editor.
+        null, // We don't need this to toggle it here in the editor.
+    );
     if (task !== null) {
         toggledLine = toggleTask({ task });
     } else {

--- a/src/InlineRenderer.ts
+++ b/src/InlineRenderer.ts
@@ -107,10 +107,7 @@ export class InlineRenderer {
             const dataLine: string =
                 renderedElement.getAttr('data-line') ?? '0';
             const listIndex: number = Number.parseInt(dataLine, 10);
-            const taskElement = await task.toLi({
-                parentUlElement: element,
-                listIndex,
-            });
+            const taskElement = await task.toLi(element, listIndex);
 
             // If the rendered element contains a sub-list or sub-div (e.g. the
             // folding arrow), we need to keep it.

--- a/src/InlineRenderer.ts
+++ b/src/InlineRenderer.ts
@@ -75,13 +75,13 @@ export class InlineRenderer {
                 continue;
             }
 
-            const task = Task.fromLine({
+            const task = Task.fromLine(
                 line,
                 path,
-                sectionStart: section.lineStart,
+                section.lineStart,
                 sectionIndex,
-                precedingHeader: null, // We don't need the preceding header for in-line rendering.
-            });
+                null, // We don't need the preceding header for in-line rendering.
+            );
             if (task !== null) {
                 fileTasks.push(task);
                 sectionIndex++;

--- a/src/LivePreviewExtension.ts
+++ b/src/LivePreviewExtension.ts
@@ -60,16 +60,16 @@ class LivePreviewExtension implements PluginValue {
         const { state } = this.view;
         const position = this.view.posAtDOM(target);
         const line = state.doc.lineAt(position);
-        const task = Task.fromLine({
-            line: line.text,
+        const task = Task.fromLine(
+            line.text,
             // None of this data is relevant here.
             // The task is created, toggled, and written back to the CM6 document,
             // replacing the old task in-place.
-            path: '',
-            sectionStart: 0,
-            sectionIndex: 0,
-            precedingHeader: null,
-        });
+            '',
+            0,
+            0,
+            null,
+        );
 
         console.debug(
             `Live Preview Extension: toggle called. Position: ${position} Line: ${line.text}`,

--- a/src/Query/Group.ts
+++ b/src/Query/Group.ts
@@ -162,7 +162,7 @@ export class Group {
     }
 
     private static groupByBacklink(task: Task): string[] {
-        const linkText = task.getLinkText({ isFilenameUnique: true });
+        const linkText = task.getLinkText(true);
         if (linkText === null) {
             return ['Unknown Location'];
         }

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -188,12 +188,12 @@ class QueryRenderChild extends MarkdownRenderChild {
             const task = tasks[i];
             const isFilenameUnique = this.isFilenameUnique({ task });
 
-            const listItem = await task.toLi({
-                parentUlElement: taskList,
-                listIndex: i,
-                layoutOptions: this.query.layoutOptions,
+            const listItem = await task.toLi(
+                taskList,
+                i,
+                this.query.layoutOptions,
                 isFilenameUnique,
-            });
+            );
 
             // Remove all footnotes. They don't re-appear in another document.
             const footnotes = listItem.querySelectorAll('[data-footnote-id]');
@@ -315,7 +315,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         if (shortMode) {
             linkText = ' 🔗';
         } else {
-            linkText = task.getLinkText({ isFilenameUnique }) ?? '';
+            linkText = task.getLinkText(isFilenameUnique) ?? '';
         }
 
         link.setText(linkText);

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -182,22 +182,16 @@ export class Task {
      * @param {number} sectionStart - Line number where the section starts that contains this task.
      * @param {number} sectionIndex - The index of the nth task in its section.
      * @param {(string | null)} precedingHeader - The header before this task.
-     * @return {*}  {(Task | null)}
+     * @return {(Task | null)}
      * @memberof Task
      */
-    public static fromLine({
-        line,
-        path,
-        sectionStart,
-        sectionIndex,
-        precedingHeader,
-    }: {
-        line: string;
-        path: string;
-        sectionStart: number;
-        sectionIndex: number;
-        precedingHeader: string | null;
-    }): Task | null {
+    public static fromLine(
+        line: string,
+        path: string,
+        sectionStart: number,
+        sectionIndex: number,
+        precedingHeader: string | null,
+    ): Task | null {
         // Check the line to see if it is a markdown task.
         const regexMatch = line.match(Task.taskRegex);
         if (regexMatch === null) {
@@ -240,15 +234,15 @@ export class Task {
         // Keep matching and removing special strings from the end of the
         // description in any order. The loop should only run once if the
         // strings are in the expected order after the description.
-        let matched: boolean;
-        let priority: Priority = Priority.None;
+        let matched = false;
+        let priority = Priority.None;
         let startDate: Moment | null = null;
         let scheduledDate: Moment | null = null;
         let dueDate: Moment | null = null;
         let doneDate: Moment | null = null;
-        let recurrenceRule: string = '';
+        let recurrenceRule = '';
         let recurrence: Recurrence | null = null;
-        let tags: any = [];
+        let tags: string[] = [];
         // Tags that are removed from the end while parsing, but we want to add them back for being part of the description.
         // In the original task description they are possibly mixed with other components
         // (e.g. #tag1 <due date> #tag2), they do not have to all trail all task components,

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -780,6 +780,30 @@ export class Task {
         return true;
     }
 
+    /**
+     * Search for the global filter for the purpose of removing it from the description, but do so only
+     * if it is a separate word (preceding the beginning of line or a space and followed by the end of line
+     * or a space), because we don't want to cut-off nested tags like #task/subtag.
+     * If the global filter exists as part of a nested tag, we keep it untouched.
+     */
+    public getDescriptionWithoutGlobalFilter() {
+        const { globalFilter } = getSettings();
+        let description = this.description;
+        if (globalFilter.length === 0) return description;
+        // This matches the global filter (after escaping it) only when it's a complete word
+        const globalFilterRegex = RegExp(
+            '(^|\\s)' + this.escapeRegExp(globalFilter) + '($|\\s)',
+            'ug',
+        );
+        if (this.description.search(globalFilterRegex) > -1) {
+            description = description
+                .replace(globalFilterRegex, '$1$2')
+                .replace('  ', ' ')
+                .trim();
+        }
+        return description;
+    }
+
     private addTooltip(
         element: HTMLElement,
         isFilenameUnique: boolean | undefined,
@@ -860,29 +884,5 @@ export class Task {
         // a ? (all 3) or a ?< (! and =).
         // So theoretically if the ? are all escaped, those three characters do not have to be.
         return s.replace(/([.*+?^${}()|[\]/\\])/g, '\\$1');
-    }
-
-    /**
-     * Search for the global filter for the purpose of removing it from the description, but do so only
-     * if it is a separate word (preceding the beginning of line or a space and followed by the end of line
-     * or a space), because we don't want to cut-off nested tags like #task/subtag.
-     * If the global filter exists as part of a nested tag, we keep it untouched.
-     */
-    public getDescriptionWithoutGlobalFilter() {
-        const { globalFilter } = getSettings();
-        let description = this.description;
-        if (globalFilter.length === 0) return description;
-        // This matches the global filter (after escaping it) only when it's a complete word
-        const globalFilterRegex = RegExp(
-            '(^|\\s)' + this.escapeRegExp(globalFilter) + '($|\\s)',
-            'ug',
-        );
-        if (this.description.search(globalFilterRegex) > -1) {
-            description = description
-                .replace(globalFilterRegex, '$1$2')
-                .replace('  ', ' ')
-                .trim();
-        }
-        return description;
     }
 }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -484,7 +484,7 @@ export class Task {
         checkbox.setAttr('data-line', listIndex);
 
         if (layoutOptions?.shortMode) {
-            this.addTooltip({ element: textSpan, isFilenameUnique });
+            this.addTooltip(textSpan, isFilenameUnique);
         }
 
         return li;
@@ -780,13 +780,10 @@ export class Task {
         return true;
     }
 
-    private addTooltip({
-        element,
-        isFilenameUnique,
-    }: {
-        element: HTMLElement;
-        isFilenameUnique: boolean | undefined;
-    }): void {
+    private addTooltip(
+        element: HTMLElement,
+        isFilenameUnique: boolean | undefined,
+    ): void {
         element.addEventListener('mouseenter', () => {
             const tooltip = element.createDiv();
             tooltip.addClasses(['tooltip', 'mod-right']);
@@ -801,40 +798,28 @@ export class Task {
             if (this.startDate) {
                 const startDateDiv = tooltip.createDiv();
                 startDateDiv.setText(
-                    Task.toTooltipDate({
-                        signifier: startDateSymbol,
-                        date: this.startDate,
-                    }),
+                    Task.toTooltipDate(startDateSymbol, this.startDate),
                 );
             }
 
             if (this.scheduledDate) {
                 const scheduledDateDiv = tooltip.createDiv();
                 scheduledDateDiv.setText(
-                    Task.toTooltipDate({
-                        signifier: scheduledDateSymbol,
-                        date: this.scheduledDate,
-                    }),
+                    Task.toTooltipDate(scheduledDateSymbol, this.scheduledDate),
                 );
             }
 
             if (this.dueDate) {
                 const dueDateDiv = tooltip.createDiv();
                 dueDateDiv.setText(
-                    Task.toTooltipDate({
-                        signifier: dueDateSymbol,
-                        date: this.dueDate,
-                    }),
+                    Task.toTooltipDate(dueDateSymbol, this.dueDate),
                 );
             }
 
             if (this.doneDate) {
                 const doneDateDiv = tooltip.createDiv();
                 doneDateDiv.setText(
-                    Task.toTooltipDate({
-                        signifier: doneDateSymbol,
-                        date: this.doneDate,
-                    }),
+                    Task.toTooltipDate(doneDateSymbol, this.doneDate),
                 );
             }
 
@@ -850,13 +835,7 @@ export class Task {
         });
     }
 
-    private static toTooltipDate({
-        signifier,
-        date,
-    }: {
-        signifier: string;
-        date: Moment;
-    }): string {
+    private static toTooltipDate(signifier: string, date: Moment): string {
         return `${signifier} ${date.format(Task.dateFormat)} (${date.from(
             window.moment().startOf('day'),
         )})`;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -396,18 +396,13 @@ export class Task {
         });
     }
 
-    public async toLi({
-        parentUlElement,
-        listIndex,
-        layoutOptions,
-        isFilenameUnique,
-    }: {
-        parentUlElement: HTMLElement;
+    public async toLi(
+        parentUlElement: HTMLElement,
         /** The nth item in this list (including non-tasks). */
-        listIndex: number;
-        layoutOptions?: LayoutOptions;
-        isFilenameUnique?: boolean;
-    }): Promise<HTMLLIElement> {
+        listIndex: number,
+        layoutOptions?: LayoutOptions,
+        isFilenameUnique?: boolean,
+    ): Promise<HTMLLIElement> {
         const li: HTMLLIElement = parentUlElement.createEl('li');
         li.addClasses(['task-list-item', 'plugin-tasks-list-item']);
 
@@ -651,15 +646,11 @@ export class Task {
     /**
      * Returns the text that should be displayed to the user when linking to the origin of the task
      *
-     * @param isFilenameUnique {boolean|null} Whether the name of the file that contains the task is unique in the vault.
+     * @param isFilenameUnique {boolean|undefined} Whether the name of the file that contains the task is unique in the vault.
      *                                        If it is undefined, the outcome will be the same as with a unique file name: the file name only.
      *                                        If set to `true`, the full path will be returned.
      */
-    public getLinkText({
-        isFilenameUnique,
-    }: {
-        isFilenameUnique: boolean | undefined;
-    }): string | null {
+    public getLinkText(isFilenameUnique?: boolean): string | null {
         let linkText: string | null;
         if (isFilenameUnique) {
             linkText = this.filename;
@@ -847,7 +838,7 @@ export class Task {
                 );
             }
 
-            const linkText = this.getLinkText({ isFilenameUnique });
+            const linkText = this.getLinkText(isFilenameUnique);
             if (linkText) {
                 const backlinkDiv = tooltip.createDiv();
                 backlinkDiv.setText(`🔗 ${linkText}`);

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -107,7 +107,6 @@
         parsedDone = parseDate('done', editableTask.doneDate);
     }
 
-
     onMount(() => {
         const { globalFilter } = getSettings();
         const description = task.getDescriptionWithoutGlobalFilter();
@@ -116,7 +115,10 @@
         // when saving the task.
         // Another special case is when the global filter is empty: in this case there's an "empty" match in the `indexOf`
         // (it returns 0), and thus we *don't* set addGlobalFilterOnSave.
-        if (description != task.description || description.indexOf(globalFilter) == -1)
+        if (
+            description != task.description ||
+            description.indexOf(globalFilter) == -1
+        )
             addGlobalFilterOnSave = true;
         let priority: 'none' | 'low' | 'medium' | 'high' = 'none';
         if (task.priority === Priority.Low) {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -233,13 +233,7 @@ type TagParsingExpectations = {
 };
 
 function constructTaskFromLine(line: string) {
-    return Task.fromLine({
-        line,
-        path: 'file.md',
-        sectionStart: 0,
-        sectionIndex: 0,
-        precedingHeader: '',
-    });
+    return Task.fromLine(line, 'file.md', 0, 0, '');
 }
 
 describe('parsing tags', () => {

--- a/tests/TestHelpers.ts
+++ b/tests/TestHelpers.ts
@@ -9,13 +9,7 @@ export function fromLine({
     path?: string;
     precedingHeader?: string | null;
 }) {
-    return Task.fromLine({
-        line,
-        path,
-        precedingHeader,
-        sectionIndex: 0,
-        sectionStart: 0,
-    })!;
+    return Task.fromLine(line, path, 0, 0, precedingHeader)!;
 }
 
 export function createTasksFromMarkdown(
@@ -26,13 +20,7 @@ export function createTasksFromMarkdown(
     const taskLines = tasksAsMarkdown.split('\n');
     const tasks: Task[] = [];
     for (const line of taskLines) {
-        const task = Task.fromLine({
-            line: line,
-            path: path,
-            precedingHeader: precedingHeader,
-            sectionIndex: 0,
-            sectionStart: 0,
-        });
+        const task = Task.fromLine(line, path, 0, 0, precedingHeader);
         if (task) {
             tasks.push(task);
         }

--- a/tests/TestingTools/FilterTestHelpers.ts
+++ b/tests/TestingTools/FilterTestHelpers.ts
@@ -84,14 +84,7 @@ export function shouldSupportFiltering(
     const query = new Query({ source: filters.join('\n') });
 
     const tasks = allTaskLines.map(
-        (taskLine) =>
-            Task.fromLine({
-                line: taskLine,
-                sectionStart: 0,
-                sectionIndex: 0,
-                path: '',
-                precedingHeader: '',
-            }) as Task,
+        (taskLine) => Task.fromLine(taskLine, '', 0, 0, '')!,
     );
 
     // Act


### PR DESCRIPTION
* Skips constructor so that usage of spread syntax continues to be ok there
* Refactor all other functions in Task.ts (whose callers do not rely on that syntax)
* Submitting here for code scanning